### PR TITLE
Upgrade zapthreads 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "use-text-selection": "^1.1.5",
     "usehooks-ts": "^2.9.1",
     "ws": "^8.13.0",
-    "zapthreads": "0.1.0"
+    "zapthreads": "0.2.0"
   },
   "devDependencies": {
     "@types/node": "^20.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ dependencies:
     specifier: ^8.13.0
     version: 8.13.0
   zapthreads:
-    specifier: 0.1.0
-    version: 0.1.0
+    specifier: 0.2.0
+    version: 0.2.0
 
 devDependencies:
   '@types/node':
@@ -2874,6 +2874,36 @@ packages:
       solid-js: 1.7.8
     dev: false
 
+  /@solid-primitives/event-listener@2.3.0(solid-js@1.7.8):
+    resolution: {integrity: sha512-0DS7DQZvCExWSpurVZC9/wjI8RmkhuOtWOy6Pp1Woq9ElMT9/bfjNpkwXsOwisLpcTqh9eUs17kp7jtpWcC20w==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/utils': 6.2.1(solid-js@1.7.8)
+      solid-js: 1.7.8
+    dev: false
+
+  /@solid-primitives/resize-observer@2.0.22(solid-js@1.7.8):
+    resolution: {integrity: sha512-ps8UIFiGsNxZaWBKSH0Py0Nx5PDd7NtUGHkN/04SNRYgtTvlPF768rk0ksPlDgpIwYmBLIoC9qvQmQPaHF4F5w==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/event-listener': 2.3.0(solid-js@1.7.8)
+      '@solid-primitives/rootless': 1.4.2(solid-js@1.7.8)
+      '@solid-primitives/static-store': 0.0.5(solid-js@1.7.8)
+      '@solid-primitives/utils': 6.2.1(solid-js@1.7.8)
+      solid-js: 1.7.8
+    dev: false
+
+  /@solid-primitives/rootless@1.4.2(solid-js@1.7.8):
+    resolution: {integrity: sha512-ynI/2aEOPyc14IKCX6yDBqnsAYCoLbaP9V/jejEWMVKOT2ZdV2ZxdftaLimOpWPpvjyti5DUJIGTOfLaNb7jlg==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/utils': 6.2.1(solid-js@1.7.8)
+      solid-js: 1.7.8
+    dev: false
+
   /@solid-primitives/scheduled@1.4.0(solid-js@1.7.8):
     resolution: {integrity: sha512-j4xMdsvluO8xv+M62gSUrUEKiqT0qlymM9PhXiqIzpnRNm5rrP+bHpG0BDhqkNe6fDEDb+W1L7OCmiG+qveBvQ==}
     peerDependencies:
@@ -2882,8 +2912,25 @@ packages:
       solid-js: 1.7.8
     dev: false
 
+  /@solid-primitives/static-store@0.0.5(solid-js@1.7.8):
+    resolution: {integrity: sha512-ssQ+s/wrlFAEE4Zw8GV499yBfvWx7SMm+ZVc11wvao4T5xg9VfXCL9Oa+x4h+vPMvSV/Knv5LrsLiUa+wlJUXQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      '@solid-primitives/utils': 6.2.1(solid-js@1.7.8)
+      solid-js: 1.7.8
+    dev: false
+
   /@solid-primitives/utils@6.2.0(solid-js@1.7.8):
     resolution: {integrity: sha512-T62WlLwKkbmicsw/xpwMQyv9MmZRSaVyutXfS5icc9v0cb8qGMUxRxr5LVvZHYQCZ9DEFboZB0r711xsbVBbeA==}
+    peerDependencies:
+      solid-js: ^1.6.12
+    dependencies:
+      solid-js: 1.7.8
+    dev: false
+
+  /@solid-primitives/utils@6.2.1(solid-js@1.7.8):
+    resolution: {integrity: sha512-TsecNzxiO5bLfzqb4OOuzfUmdOROcssuGqgh5rXMMaasoFZ3GoveUgdY1wcf17frMJM7kCNGNuK34EjErneZkg==}
     peerDependencies:
       solid-js: ^1.6.12
     dependencies:
@@ -4745,6 +4792,10 @@ packages:
     resolution: {integrity: sha512-8TGPgM3pAD+VRsMtUMNknRz3kzqwp/gPALrWMsDnmC1mKqJwpWyooQRLMcbTwq8z8YwSmuj+ZYvc+xCuEpkssA==}
     dependencies:
       '@babel/runtime': 7.22.6
+    dev: false
+
+  /idb@7.1.1:
+    resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
     dev: false
 
   /ignore@5.2.4:
@@ -7460,14 +7511,18 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /zapthreads@0.1.0:
-    resolution: {integrity: sha512-XYztZbRUCf1AXBNQvfMYHNvuw/hhj2f4uSAodUAMkvQPx8Fq7NdV/OsZf5i7upcReHL46we7165aOYFfmhN31w==}
+  /zapthreads@0.2.0:
+    resolution: {integrity: sha512-R5kvDjq7SN4adwk9zR2APJyZk9Ni+QMkAkiQbAIINu94zl3+g7nNHC+VgEnqcq6lYSnH9NBL7YgbhVU8b25TYQ==}
     dependencies:
       '@noble/curves': 1.0.0
       '@noble/hashes': 1.3.0
       '@scure/base': 1.1.1
       '@solid-primitives/autofocus': 0.0.107(solid-js@1.7.8)
+      '@solid-primitives/resize-observer': 2.0.22(solid-js@1.7.8)
       '@solid-primitives/scheduled': 1.4.0(solid-js@1.7.8)
+      fast-deep-equal: 3.1.3
+      idb: 7.1.1
+      light-bolt11-decoder: 3.0.0
       nano-markdown: 1.2.2
       solid-element: 1.7.1(solid-js@1.7.8)
       solid-js: 1.7.8

--- a/src/components/LongFormNote.tsx
+++ b/src/components/LongFormNote.tsx
@@ -274,30 +274,6 @@ export default function LongFormNote({
 
       {event && event.encode && (
         <Box>
-          <style>
-            {colorMode == "light"
-              ? `
-            :root {
-              --ztr-font: Inter;
-              --ztr-text-color: #2B2B2B;
-              --ztr-textarea-color: #2B2B2B;
-              --ztr-icon-color: #656565;
-              --ztr-link-color:  #92379c;
-              --ztr-login-button-color: var(--chakra-colors-orange-500);
-              --ztr-background-color: rgba(0, 0, 0, 0.03);
-            }
-          `
-              : `
-            :root {
-              --ztr-font: Inter;
-              --ztr-text-color: #dedede;
-              --ztr-icon-color: #656565;
-              --ztr-link-color: #e4b144;
-              --ztr-login-button-color: #5e584b;
-              --ztr-background-color: rgba(255, 255, 255, 0.05);
-            }
-          `}
-          </style>
           <Thread anchor={event.encode()} />
         </Box>
       )}

--- a/src/components/nostr/Thread.tsx
+++ b/src/components/nostr/Thread.tsx
@@ -1,49 +1,30 @@
 import { useAtom } from "jotai";
-import { useColorMode } from "@chakra-ui/react";
+import { nip19 } from "nostr-tools";
+import { ZapThreadsAttributes } from "zapthreads";
 import "zapthreads";
+
 import { pubkeyAtom, relaysAtom } from "@habla/state";
+import { useMemo } from "react";
 
 export default function Thread({ anchor }) {
   const [loggedInPubkey] = useAtom(pubkeyAtom);
   const [defaultRelays] = useAtom(relaysAtom);
-  const { colorMode } = useColorMode();
+  const npub = useMemo(() => {
+    return loggedInPubkey ? nip19.npubEncode(loggedInPubkey) : '';
+  }, [loggedInPubkey]);
 
-  return (
-    <>
-      <style>
-        {colorMode == "light"
-          ? `
-            :root {
-              --ztr-font: Inter;
-              --ztr-font-size: 15px;
-              --ztr-text-color: #2B2B2B;
-              --ztr-textarea-color: #2B2B2B;
-              --ztr-icon-color: #656565;
-              --ztr-link-color:  #92379c;
-              --ztr-login-button-color: var(--chakra-colors-orange-500);
-              --ztr-background-color: rgba(0, 0, 0, 0.03);
-            }
-          `
-          : `
-            :root {
-              --ztr-font: Inter;
-              --ztr-font-size: 15px;
-              --ztr-text-color: #dedede;
-              --ztr-icon-color: #656565;
-              --ztr-link-color: #e4b144;
-              --ztr-login-button-color: #5e584b;
-              --ztr-background-color: rgba(255, 255, 255, 0.05);
-            }
-          `}
-      </style>
-      <zap-threads
-        anchor={anchor}
-        pubkey={loggedInPubkey}
-        relays={defaultRelays}
-        disable-likes={true}
-        disable-zaps={true}
-        close-on-eose={true}
-      />
-    </>
-  );
+  return <zap-threads
+    anchor={anchor}
+    npub={npub}
+    relays={defaultRelays}
+    disable="likes: true, zaps: true"
+  />;
+}
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'zap-threads': ZapThreadsAttributes;
+    }
+  }
 }

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -36,6 +36,14 @@ const styles = {
       color: "#16161D",
       bg: "#FFD1DC",
     },
+    ":root": {
+      // Zapthreads custom styles
+      '--ztr-font': 'Inter',
+      '--ztr-text-color': mode('#2B2B2B', '#DEDEDE')(props),
+      '--ztr-font-size': '15px',
+      '--ztr-login-button-color': mode('var(--chakra-colors-orange-600)', 'var(--chakra-colors-orange-300)')(props),
+      '--ztr-link-color': mode('var(--chakra-colors-orange-600)', 'var(--chakra-colors-orange-300)')(props)
+    }
   }),
 };
 


### PR DESCRIPTION
Tested and should be good to go!  Do let me know if you find issues

Remember `publish:true` can be added to `disable` in order to disable publishing for testing

I'm confused about the dependencies now, is pnpm adding zapthreads dependencies to Habla? Unless it's not using the bundled version