### PR TITLE
Fix bunker parsing on iOS and non-Chrome browsers

### DIFF
--- a/src/components/nostr/Login.tsx
+++ b/src/components/nostr/Login.tsx
@@ -148,7 +148,7 @@ function LoginDialog({ isOpen, onClose }) {
       if (nostrConnect?.includes("bunker://")) {
         const asURL = new URL(nostrConnect);
         const relays = asURL.searchParams.getAll("relay");
-        const pubkey = asURL.pathname.replace(/^\/\//, "");
+        const pubkey = asURL.hostname || asURL.pathname.replace(/^\/\//, "");
         return { relays, pubkey };
       } else {
         const user = await NDKUser.fromNip05(nostrConnect, ndk);


### PR DESCRIPTION
Some browsers put pubkey part of bunker url into hostname, not pathname.