### PR TITLE
Do not allow /write for pubkey users

### DIFF
--- a/src/pages/write.tsx
+++ b/src/pages/write.tsx
@@ -5,9 +5,10 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { Text } from "@chakra-ui/react";
 import { useAtom } from "jotai";
 
-import { pubkeyAtom } from "@habla/state";
+import { pubkeyAtom, sessionAtom } from "@habla/state";
 import Layout from "@habla/layouts/Wide";
 import Metadata from "@habla/components/Metadata";
+import { useAtomValue } from "jotai/index";
 const Write = dynamic(() => import("@habla/components/Write"), {
   ssr: false,
 });
@@ -19,7 +20,21 @@ export default function WritePage() {
     title: t("habla"),
     summary: t("tagline"),
   };
+
+  const session = useAtomValue(sessionAtom);
   const [pubkey] = useAtom(pubkeyAtom);
+
+  if (session && session.method === 'pubkey') {
+    return (
+      <>
+        <Metadata url={url} metadata={metadata} />
+        <Layout>
+          <Text>Account is in read-only mode. Make sure Habla has access to your private key.</Text>
+        </Layout>
+      </>
+    )
+  }
+
   return (
     <>
       <Metadata url={url} metadata={metadata} />


### PR DESCRIPTION
First time trying Habla. When posting my first long-form https://primal.net/e/note1zz4397fe0khd6s07vf32ackgqd2zfgg8h5wrc9w5wznanmapucdq3jwywq i noticed the 'post' button didn't do anything.

After a while figured out that i was signed in with pubkey only and so account was in read mode, yet /write was available. When you then hit 'post' in the post modal there are no warnings/nothing happens. It feels broken.

This PR only adds a warning for people signed in without nip7, nip46 or privkey